### PR TITLE
Implement root motion support in SmartsuitPoseNode

### DIFF
--- a/Plugins/Smartsuit/Source/Smartsuit/Private/SmartsuitPoseNode.cpp
+++ b/Plugins/Smartsuit/Source/Smartsuit/Private/SmartsuitPoseNode.cpp
@@ -752,8 +752,29 @@ void FSmartsuitPoseNode::EvaluateSkeletalControl_AnyThread(FComponentSpacePoseCo
 	//	ApplySmartsuitTransform(BoneMap.hip, SuitRotation, SuitLocation, FVector(1, 1, 1), SuitTransformBoneControlSpace, SkelComp, MeshBases);
 	//}
 
+	// Apply root motion, if relevant
+	if (bApplyRootMotion)
+	{
+		FVector NewRootPosition = hipPosition;
+		NewRootPosition.Z = 0.0f;
 
+		// Make sure to initialize root motion position, otherwise we will get erronous results
+		if (!bInitializedRootPosition)
+		{
+			OldRootPosition = NewRootPosition;
+			bInitializedRootPosition = true;
+		}
 
+		FVector RootDelta = NewRootPosition - OldRootPosition;
+		OldRootPosition = NewRootPosition;
+
+		FTransform NewRootTransform;
+		NewRootTransform.SetRotation(FQuat::Identity);
+		NewRootTransform.SetScale3D(FVector::OneVector);
+		NewRootTransform.SetTranslation(RootDelta);
+
+		Output.AnimInstanceProxy->GetExtractedRootMotion().Accumulate(NewRootTransform);
+	}
 
 	ApplySmartsuitRotation(BoneMap.stomach, stomachQuat* stomachExpected, hipQuat, TestBoneControlSpace, SkelComp, MeshBases);
 	ApplySmartsuitRotation(BoneMap.chest, chestQuat* chestExpected, hipQuat, TestBoneControlSpace, SkelComp, MeshBases);

--- a/Plugins/Smartsuit/Source/Smartsuit/Public/SmartsuitPoseNode.h
+++ b/Plugins/Smartsuit/Source/Smartsuit/Public/SmartsuitPoseNode.h
@@ -234,6 +234,10 @@ struct SMARTSUIT_API FSmartsuitPoseNode : public FAnimNode_SkeletalControlBase
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = SourceData, meta = (PinShownByDefault))
 	FName RokokoActorName;
 
+	/** If enabled, root motion will be applied from this pose. This can help prevent characters from moving through walls etc. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = RootMotion, meta = (PinShownByDefault))
+	bool bApplyRootMotion;
+
 	/// @private
 	SmartsuitTPose TPose;
 	/// @private
@@ -299,5 +303,9 @@ private:
 
 	FLiveLinkClientReference LiveLinkClient_GameThread;
 	ILiveLinkClient* LiveLinkClient_AnyThread;
+
+	// Root motion support 
+	bool bInitializedRootPosition{};
+	FVector OldRootPosition{};
 
 };


### PR DESCRIPTION
This PR implements root motion support in the SmartsuitPoseNode, allowing root motion to be accumulated for characters via this node in the animation blueprint, and lets physical actors control virtual characters in live production as if they were controlling the characters in a game (being able to walk stairs, drop off ledges, hit obstacles etc.).

This makes it such that characters can not walk through walls in the virtual environment, but instead stops when they hit obstacles. This may cause a drift between the physical actor position and the virtual actor for live production, however with enough physical space to account for this, it's not a problem. 

It currently calculates the root position from the hip, and projects it to the local floor (Z 0.0). This has proven to work well for our purposes, however your mileage may vary (and creating an enum option to select different root position calculations may be a good idea in the future).

Exposes the functionality as a simple checkbox in the animation blueprint node.

![image](https://github.com/Rokoko/rokoko-studio-live-unreal-engine/assets/850310/dc5b85a6-8d79-4966-8a1b-e9036b56c795)
