### PR TITLE
Implement arm/shoulder space to pose node

### DIFF
--- a/Plugins/Smartsuit/Source/Smartsuit/Private/SmartsuitPoseNode.cpp
+++ b/Plugins/Smartsuit/Source/Smartsuit/Private/SmartsuitPoseNode.cpp
@@ -565,6 +565,11 @@ void FSmartsuitPoseNode::EvaluateSkeletalControl_AnyThread(FComponentSpacePoseCo
 	FQuat modifier = FQuat::MakeFromEuler(FVector(0, 0, 180));
 	FQuat forwardModifier = FQuat::MakeFromEuler(FVector(0, 0, 90));
 
+	// These duplicate variables are a bit redundant in their current state, however lets keep these around in case we need to negate an axis for example
+	FQuat LeftShoulderSpace = FQuat::MakeFromEuler(FVector(ShoulderSpace, 0.0f, 0.0f));
+	FQuat RightShoulderSpace = FQuat::MakeFromEuler(FVector(ShoulderSpace, 0.0f, 0.0f));
+	FQuat LeftArmSpace = FQuat::MakeFromEuler(FVector(ArmSpace, 0.0f, 0.0f));
+	FQuat RightArmSpace = FQuat::MakeFromEuler(FVector(ArmSpace, 0.0f, 0.0f));
 
 	FQuat hipQuat =						GetRotation3(SmartsuitBones::hip, SubjectFrameData);// *modifier;
 	FVector hipPosition =				GetPosition3(SmartsuitBones::hip, SubjectFrameData);
@@ -572,12 +577,12 @@ void FSmartsuitPoseNode::EvaluateSkeletalControl_AnyThread(FComponentSpacePoseCo
 	FQuat chestQuat =					GetRotation3(SmartsuitBones::chest, SubjectFrameData);
 	FQuat neckQuat =					GetRotation3(SmartsuitBones::neck, SubjectFrameData);
 	FQuat headQuat =					GetRotation3(SmartsuitBones::head, SubjectFrameData);
-	FQuat leftShoulderQuat =			GetRotation3(SmartsuitBones::leftShoulder, SubjectFrameData);
-	FQuat leftArmQuat =					GetRotation3(SmartsuitBones::leftUpperArm, SubjectFrameData);
+	FQuat leftShoulderQuat =			GetRotation3(SmartsuitBones::leftShoulder, SubjectFrameData) * LeftShoulderSpace;
+	FQuat leftArmQuat =					GetRotation3(SmartsuitBones::leftUpperArm, SubjectFrameData) * LeftArmSpace;
 	FQuat leftForearmQuat =				GetRotation3(SmartsuitBones::leftLowerArm, SubjectFrameData);
 	FQuat leftHandQuat =				GetRotation3(SmartsuitBones::leftHand, SubjectFrameData);
-	FQuat rightShoulderQuat =			GetRotation3(SmartsuitBones::rightShoulder, SubjectFrameData);
-	FQuat rightArmQuat =				GetRotation3(SmartsuitBones::rightUpperArm, SubjectFrameData);
+	FQuat rightShoulderQuat =			GetRotation3(SmartsuitBones::rightShoulder, SubjectFrameData) * RightShoulderSpace;
+	FQuat rightArmQuat =				GetRotation3(SmartsuitBones::rightUpperArm, SubjectFrameData) * RightArmSpace;
 	FQuat rightForearmQuat =			GetRotation3(SmartsuitBones::rightLowerArm, SubjectFrameData);
 	FQuat rightHandQuat =				GetRotation3(SmartsuitBones::rightHand, SubjectFrameData);
 	FQuat leftUpLegQuat =				GetRotation3(SmartsuitBones::leftUpLeg, SubjectFrameData);

--- a/Plugins/Smartsuit/Source/Smartsuit/Public/SmartsuitPoseNode.h
+++ b/Plugins/Smartsuit/Source/Smartsuit/Public/SmartsuitPoseNode.h
@@ -238,6 +238,14 @@ struct SMARTSUIT_API FSmartsuitPoseNode : public FAnimNode_SkeletalControlBase
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = RootMotion, meta = (PinShownByDefault))
 	bool bApplyRootMotion;
 
+	/** Use to shoulder space. Tweaks the clavicle/shoulder rotation, around approx. the character up axis. Make sure that skeleton axis are imported correctly into Unreal! Defaults to 0.0f */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Space, meta = (PinShownByDefault))
+	float ShoulderSpace{0.0f};
+
+	/** Use to tweak arm space. Tweaks the upper arm rotation around approx. the character forward axis. Make sure that skeleton axis are imported correctly into Unreal! Defaults to 0.0f */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Space, meta = (PinShownByDefault))
+	float ArmSpace{ 0.0f };
+
 	/// @private
 	SmartsuitTPose TPose;
 	/// @private


### PR DESCRIPTION
This commit implements options to tweak armspace and shoulder space in the pose node, similar to some options that exist in software like Mixamo for example.

Useful to prevent pose mismatches between rokoko and unreal during live productions, and helps create a more natural result. 

Provides two scalar parameters for Shoulder Space and Arm Space, interpreted as degrees of rotation.

Like with some other animation blueprint nodes, such as the LookAt node, it's important that the character skeleton axes has been imported properly into Unreal. I belive it's X+ primary axis and Z- secondary axis, but I might be wrong. For our uses, we have used the Blender 3.3's "Unreal Engine" preset when exporting our FBXs, and this has worked well for us.

If options are set to 0.0 (the default), no effect is applied.

Before
![image](https://github.com/Rokoko/rokoko-studio-live-unreal-engine/assets/850310/a7106ec4-6d6c-4a99-8cb8-b7471e3623b3)

After
![image2](https://github.com/Rokoko/rokoko-studio-live-unreal-engine/assets/850310/01ac50f7-e1c9-4e88-b7e6-73b3f11f2255)

Rokoko
![image3](https://github.com/Rokoko/rokoko-studio-live-unreal-engine/assets/850310/3e20a82b-9c0c-4d09-92e3-26c3965906c1)

Node options
![image4](https://github.com/Rokoko/rokoko-studio-live-unreal-engine/assets/850310/417be42b-2d9d-43f9-81d8-3854d1a1152c)
