### PR TITLE
Fix linux compilation and deprecations

### DIFF
--- a/Plugins/Smartsuit/Source/Smartsuit/Private/RokokoRemote.cpp
+++ b/Plugins/Smartsuit/Source/Smartsuit/Private/RokokoRemote.cpp
@@ -53,7 +53,7 @@ void ARokokoRemote::OnInfoRequestComplete(FHttpRequestPtr HttpRequest, FHttpResp
 	// Deserialize the json data given Reader and the actual object to deserialize
 	if (FJsonSerializer::Deserialize(Reader, JsonObject))
 	{
-		auto& Arr = JsonObject->GetArrayField("parameters");
+		auto& Arr = JsonObject->GetArrayField(TEXT("parameters"));
 
 		TArray<FString> StringsDevices;
 		TArray<FString> StringsClips;
@@ -118,19 +118,19 @@ void ARokokoRemote::OnTrackerRequestComplete(FHttpRequestPtr HttpRequest, FHttpR
 	// Deserialize the json data given Reader and the actual object to deserialize
 	if (FJsonSerializer::Deserialize(Reader, JsonObject))
 	{
-		auto& Arr = JsonObject->GetArrayField("parameters");
+		auto& Arr = JsonObject->GetArrayField(TEXT("parameters"));
 
 		if (!Arr.IsEmpty())
 		{
 			auto& ObjectPosition = Arr[0]->AsObject();
 			auto& ObjectRotation = Arr[1]->AsObject();
 
-			FVector Position(WORLD_SCALE * ObjectPosition->GetNumberField("X"),
-				-WORLD_SCALE * ObjectPosition->GetNumberField("Z"),
-				WORLD_SCALE * ObjectPosition->GetNumberField("Y"));
+			FVector Position(WORLD_SCALE * ObjectPosition->GetNumberField(TEXT("X")),
+				-WORLD_SCALE * ObjectPosition->GetNumberField(TEXT("Z")),
+				WORLD_SCALE * ObjectPosition->GetNumberField(TEXT("Y")));
 			// TODO: do we need to convert rotation to UE coord system ?!
-			FQuat Rotation(ObjectRotation->GetNumberField("X"), ObjectRotation->GetNumberField("Y"), ObjectRotation->GetNumberField("Z"),
-				ObjectRotation->GetNumberField("W"));
+			FQuat Rotation(ObjectRotation->GetNumberField(TEXT("X")), ObjectRotation->GetNumberField(TEXT("Y")), ObjectRotation->GetNumberField(TEXT("Z")),
+				ObjectRotation->GetNumberField(TEXT("W")));
 
 			OnTrackerRequest.Broadcast(Position, Rotation);
 		}
@@ -146,7 +146,7 @@ void ARokokoRemote::OnPlaybackRequestComplete(FHttpRequestPtr HttpRequest, FHttp
 	// Deserialize the json data given Reader and the actual object to deserialize
 	if (FJsonSerializer::Deserialize(Reader, JsonObject))
 	{
-		auto& Arr = JsonObject->GetArrayField("parameters");
+		auto& Arr = JsonObject->GetArrayField(TEXT("parameters"));
 
 		if (!Arr.IsEmpty())
 		{

--- a/Plugins/Smartsuit/Source/Smartsuit/Private/SmartsuitBlueprintLibrary.cpp
+++ b/Plugins/Smartsuit/Source/Smartsuit/Private/SmartsuitBlueprintLibrary.cpp
@@ -280,9 +280,9 @@ void USmartsuitBlueprintLibrary::JSONTest()
 FVector USmartsuitBlueprintLibrary::GetVectorField(TSharedPtr<FJsonObject> jsonObject)
 {
 	FVector ReturnVal;
-	ReturnVal.X = jsonObject->GetNumberField("x");
-	ReturnVal.Y = jsonObject->GetNumberField("y");
-	ReturnVal.Z = jsonObject->GetNumberField("z");
+	ReturnVal.X = jsonObject->GetNumberField(TEXT("x"));
+	ReturnVal.Y = jsonObject->GetNumberField(TEXT("y"));
+	ReturnVal.Z = jsonObject->GetNumberField(TEXT("z"));
 	return ReturnVal;
 }
 

--- a/Plugins/Smartsuit/Source/Smartsuit/Private/SmartsuitBlueprintLibrary.cpp
+++ b/Plugins/Smartsuit/Source/Smartsuit/Private/SmartsuitBlueprintLibrary.cpp
@@ -292,7 +292,7 @@ FColor USmartsuitBlueprintLibrary::GetColorField(TSharedPtr<FJsonObject> jsonObj
 	const TArray<TSharedPtr<FJsonValue>>* ColorArray = nullptr;
 	
 	FColor Color;
-	if(jsonObject->TryGetArrayField("color", ColorArray))
+	if(jsonObject->TryGetArrayField(TEXT("color"), ColorArray))
 	{
 		Color.R = (*ColorArray)[0]->AsNumber();
 		Color.G = (*ColorArray)[1]->AsNumber();
@@ -305,9 +305,9 @@ FColor USmartsuitBlueprintLibrary::GetColorField(TSharedPtr<FJsonObject> jsonObj
 FLinearColor USmartsuitBlueprintLibrary::GetFLinearColorField(TSharedPtr<FJsonObject> jsonObject)
 {
 	FLinearColor LinearColor;
-	LinearColor.R = jsonObject->GetNumberField("x");
-	LinearColor.G = jsonObject->GetNumberField("y");
-	LinearColor.B = jsonObject->GetNumberField("z");
+	LinearColor.R = jsonObject->GetNumberField(TEXT("x"));
+	LinearColor.G = jsonObject->GetNumberField(TEXT("y"));
+	LinearColor.B = jsonObject->GetNumberField(TEXT("z"));
 
 	//this is so we can properly convert the color to srgb
 	FColor NewColor = LinearColor.QuantizeRound();
@@ -318,10 +318,10 @@ FLinearColor USmartsuitBlueprintLibrary::GetFLinearColorField(TSharedPtr<FJsonOb
 FQuat USmartsuitBlueprintLibrary::GetQuaternionField(TSharedPtr<FJsonObject> jsonObject)
 {
 	FQuat ReturnVal;
-	ReturnVal.X = jsonObject->GetNumberField("x");
-	ReturnVal.Y = jsonObject->GetNumberField("y");
-	ReturnVal.Z = jsonObject->GetNumberField("z");
-	ReturnVal.W = jsonObject->GetNumberField("w");
+	ReturnVal.X = jsonObject->GetNumberField(TEXT("x"));
+	ReturnVal.Y = jsonObject->GetNumberField(TEXT("y"));
+	ReturnVal.Z = jsonObject->GetNumberField(TEXT("z"));
+	ReturnVal.W = jsonObject->GetNumberField(TEXT("w"));
 	return ReturnVal;
 }
 

--- a/Plugins/Smartsuit/Source/Smartsuit/Private/VirtualProductionFrame.cpp
+++ b/Plugins/Smartsuit/Source/Smartsuit/Private/VirtualProductionFrame.cpp
@@ -13,59 +13,59 @@ VirtualProductionFrame::~VirtualProductionFrame()
 
 FProp::FProp(bool InIsLive, TSharedPtr<FJsonObject> jsonObject)
 {
-	name = jsonObject->GetStringField("name");
+	name = jsonObject->GetStringField(TEXT("name"));
 	color = USmartsuitBlueprintLibrary::GetColorField(jsonObject);
-	position = USmartsuitBlueprintLibrary::GetVectorField(jsonObject->GetObjectField("position"));
-	rotation = USmartsuitBlueprintLibrary::GetQuaternionField(jsonObject->GetObjectField("rotation"));
+	position = USmartsuitBlueprintLibrary::GetVectorField(jsonObject->GetObjectField(TEXT("position")));
+	rotation = USmartsuitBlueprintLibrary::GetQuaternionField(jsonObject->GetObjectField(TEXT("rotation")));
 	
 	isLive = InIsLive;
 }
 
 FProfile::FProfile(TSharedPtr<FJsonObject> jsonObject)
 {
-	name = jsonObject->GetStringField("name");
-	uuid = jsonObject->GetStringField("uuid");
-	dimensions = USmartsuitBlueprintLibrary::GetVectorField(jsonObject->GetObjectField("dimensions"));
-	color = USmartsuitBlueprintLibrary::GetFLinearColorField(jsonObject->GetObjectField("color"));
-	trackerOffset = FReferencePoint(jsonObject->GetObjectField("trackeroffset"));
-	pivot = FReferencePoint(jsonObject->GetObjectField("pivot"));
+	name = jsonObject->GetStringField(TEXT("name"));
+	uuid = jsonObject->GetStringField(TEXT("uuid"));
+	dimensions = USmartsuitBlueprintLibrary::GetVectorField(jsonObject->GetObjectField(TEXT("dimensions")));
+	color = USmartsuitBlueprintLibrary::GetFLinearColorField(jsonObject->GetObjectField(TEXT("color")));
+	trackerOffset = FReferencePoint(jsonObject->GetObjectField(TEXT("trackeroffset")));
+	pivot = FReferencePoint(jsonObject->GetObjectField(TEXT("pivot")));
 
-	TArray<TSharedPtr<FJsonValue>> gripsarray = jsonObject->GetArrayField("grips");
+	TArray<TSharedPtr<FJsonValue>> gripsarray = jsonObject->GetArrayField(TEXT("grips"));
 
 	for (auto currentgrip : gripsarray)
 	{
 		grips.Add(FRadiusReferencePoint(currentgrip->AsObject()));
 	}
 
-	propType = jsonObject->GetIntegerField("propType");
+	propType = jsonObject->GetIntegerField(TEXT("propType"));
 }
 
 FReferencePoint::FReferencePoint(TSharedPtr<FJsonObject> jsonObject)
 {
-	position = USmartsuitBlueprintLibrary::GetVectorField(jsonObject->GetObjectField("position"));
+	position = USmartsuitBlueprintLibrary::GetVectorField(jsonObject->GetObjectField(TEXT("position")));
 
-	FVector TempVector = USmartsuitBlueprintLibrary::GetVectorField(jsonObject->GetObjectField("rotation"));
+	FVector TempVector = USmartsuitBlueprintLibrary::GetVectorField(jsonObject->GetObjectField(TEXT("rotation")));
 	rotation = TempVector.Rotation().Quaternion();
 }
 
 FRadiusReferencePoint::FRadiusReferencePoint(TSharedPtr<FJsonObject> jsonObject)
 {
-	radius = jsonObject->GetNumberField("radius");
-	position = USmartsuitBlueprintLibrary::GetVectorField(jsonObject->GetObjectField("position"));
-	rotation = USmartsuitBlueprintLibrary::GetQuaternionField(jsonObject->GetObjectField("rotation"));
+	radius = jsonObject->GetNumberField(TEXT("radius"));
+	position = USmartsuitBlueprintLibrary::GetVectorField(jsonObject->GetObjectField(TEXT("position")));
+	rotation = USmartsuitBlueprintLibrary::GetQuaternionField(jsonObject->GetObjectField(TEXT("rotation")));
 }
 
 FTracker::FTracker(TSharedPtr<FJsonObject> jsonObject)
 {
-	name = jsonObject->GetStringField("name");
-	connectionId = jsonObject->GetStringField("connectionId");
-	position = USmartsuitBlueprintLibrary::GetVectorField(jsonObject->GetObjectField("position"));
-	rotation = USmartsuitBlueprintLibrary::GetQuaternionField(jsonObject->GetObjectField("rotation"));
-	isLive = jsonObject->GetBoolField("isLive");
-	trackingResult = jsonObject->GetIntegerField("trackingResult");
-	trackerType = jsonObject->GetIntegerField("trackerType");
-	RenderModelName = jsonObject->GetStringField("RenderModelName");
-	battery = jsonObject->GetNumberField("battery");
+	name = jsonObject->GetStringField(TEXT("name"));
+	connectionId = jsonObject->GetStringField(TEXT("connectionId"));
+	position = USmartsuitBlueprintLibrary::GetVectorField(jsonObject->GetObjectField(TEXT("position")));
+	rotation = USmartsuitBlueprintLibrary::GetQuaternionField(jsonObject->GetObjectField(TEXT("rotation")));
+	isLive = jsonObject->GetBoolField(TEXT("isLive"));
+	trackingResult = jsonObject->GetIntegerField(TEXT("trackingResult"));
+	trackerType = jsonObject->GetIntegerField(TEXT("trackerType"));
+	RenderModelName = jsonObject->GetStringField(TEXT("RenderModelName"));
+	battery = jsonObject->GetNumberField(TEXT("battery"));
 }
 
 
@@ -195,63 +195,63 @@ FFace::FFace(TSharedPtr<FJsonObject> jsonObject, const FString& InActorName)
 {
 	faceId = InActorName;
 	actorName = InActorName;
-	if (!jsonObject->TryGetStringField("profileName", profileName))
+	if (!jsonObject->TryGetStringField(TEXT("profileName"), profileName))
 	{
 		profileName = "NOPROFILENAME for " + faceId;
 	}
 
 	constexpr float scale{ 0.01f };
-
-	eyeBlinkLeft = jsonObject->GetNumberField("eyeBlinkLeft") * scale;
-	eyeLookDownLeft = jsonObject->GetNumberField("eyeLookDownLeft") * scale;
-	eyeLookInLeft = jsonObject->GetNumberField("eyeLookInLeft") * scale;
-	eyeLookOutLeft = jsonObject->GetNumberField("eyeLookOutLeft") * scale;
-	eyeLookUpLeft = jsonObject->GetNumberField("eyeLookUpLeft") * scale;
-	eyeSquintLeft = jsonObject->GetNumberField("eyeSquintLeft") * scale;
-	eyeWideLeft = jsonObject->GetNumberField("eyeWideLeft") * scale;
-	eyeBlinkRight = jsonObject->GetNumberField("eyeBlinkRight") * scale;
-	eyeLookDownRight = jsonObject->GetNumberField("eyeLookDownRight") * scale;
-	eyeLookInRight = jsonObject->GetNumberField("eyeLookInRight") * scale;
-	eyeLookOutRight = jsonObject->GetNumberField("eyeLookOutRight") * scale;
-	eyeLookUpRight = jsonObject->GetNumberField("eyeLookUpRight") * scale;
-	eyeSquintRight = jsonObject->GetNumberField("eyeSquintRight") * scale;
-	eyeWideRight = jsonObject->GetNumberField("eyeWideRight") * scale;
-	jawForward = jsonObject->GetNumberField("jawForward") * scale;
-	jawLeft = jsonObject->GetNumberField("jawLeft") * scale;
-	jawRight = jsonObject->GetNumberField("jawRight") * scale;
-	jawOpen = jsonObject->GetNumberField("jawOpen") * scale;
-	mouthClose = jsonObject->GetNumberField("mouthClose") * scale;
-	mouthFunnel = jsonObject->GetNumberField("mouthFunnel") * scale;
-	mouthPucker = jsonObject->GetNumberField("mouthPucker") * scale;
-	mouthLeft = jsonObject->GetNumberField("mouthLeft") * scale;
-	mouthRight = jsonObject->GetNumberField("mouthRight") * scale;
-	mouthSmileLeft = jsonObject->GetNumberField("mouthSmileLeft") * scale;
-	mouthSmileRight = jsonObject->GetNumberField("mouthSmileRight") * scale;
-	mouthFrownLeft = jsonObject->GetNumberField("mouthFrownLeft") * scale;
-	mouthFrownRight = jsonObject->GetNumberField("mouthFrownRight") * scale;
-	mouthDimpleLeft = jsonObject->GetNumberField("mouthDimpleLeft") * scale;
-	mouthDimpleRight = jsonObject->GetNumberField("mouthDimpleRight") * scale;
-	mouthStretchLeft = jsonObject->GetNumberField("mouthStretchLeft") * scale;
-	mouthStretchRight = jsonObject->GetNumberField("mouthStretchRight") * scale;
-	mouthRollLower = jsonObject->GetNumberField("mouthRollLower") * scale;
-	mouthRollUpper = jsonObject->GetNumberField("mouthRollUpper") * scale;
-	mouthShrugLower = jsonObject->GetNumberField("mouthShrugLower") * scale;
-	mouthShrugUpper = jsonObject->GetNumberField("mouthShrugUpper") * scale;
-	mouthPressLeft = jsonObject->GetNumberField("mouthPressLeft") * scale;
-	mouthPressRight = jsonObject->GetNumberField("mouthPressRight") * scale;
-	mouthLowerDownLeft = jsonObject->GetNumberField("mouthLowerDownLeft") * scale;
-	mouthLowerDownRight = jsonObject->GetNumberField("mouthLowerDownRight") * scale;
-	mouthUpperUpLeft = jsonObject->GetNumberField("mouthUpperUpLeft") * scale;
-	mouthUpperUpRight = jsonObject->GetNumberField("mouthUpperUpRight") * scale;
-	browDownLeft = jsonObject->GetNumberField("browDownLeft") * scale;
-	browDownRight = jsonObject->GetNumberField("browDownRight") * scale;
-	browInnerUp = jsonObject->GetNumberField("browInnerUp") * scale;
-	browOuterUpLeft = jsonObject->GetNumberField("browOuterUpLeft") * scale;
-	browOuterUpRight = jsonObject->GetNumberField("browOuterUpRight") * scale;
-	cheekPuff = jsonObject->GetNumberField("cheekPuff") * scale;
-	cheekSquintLeft = jsonObject->GetNumberField("cheekSquintLeft") * scale;
-	cheekSquintRight = jsonObject->GetNumberField("cheekSquintRight") * scale;
-	noseSneerLeft = jsonObject->GetNumberField("noseSneerLeft") * scale;
-	noseSneerRight = jsonObject->GetNumberField("noseSneerRight") * scale;
-	tongueOut = jsonObject->GetNumberField("tongueOut") * scale;
+	//fix all number fields with the depracated Passing an ANSI string to GetNumberField 
+	eyeBlinkLeft = jsonObject->GetNumberField(TEXT("eyeBlinkLeft")) * scale;
+	eyeLookDownLeft = jsonObject->GetNumberField(TEXT("eyeLookDownLeft")) * scale;
+	eyeLookInLeft = jsonObject->GetNumberField(TEXT("eyeLookInLeft")) * scale;
+	eyeLookOutLeft = jsonObject->GetNumberField(TEXT("eyeLookOutLeft")) * scale;
+	eyeLookUpLeft = jsonObject->GetNumberField(TEXT("eyeLookUpLeft")) * scale;
+	eyeSquintLeft = jsonObject->GetNumberField(TEXT("eyeSquintLeft")) * scale;
+	eyeWideLeft = jsonObject->GetNumberField(TEXT("eyeWideLeft")) * scale;
+	eyeBlinkRight = jsonObject->GetNumberField(TEXT("eyeBlinkRight")) * scale;
+	eyeLookDownRight = jsonObject->GetNumberField(TEXT("eyeLookDownRight")) * scale;
+	eyeLookInRight = jsonObject->GetNumberField(TEXT("eyeLookInRight")) * scale;
+	eyeLookOutRight = jsonObject->GetNumberField(TEXT("eyeLookOutRight")) * scale;
+	eyeLookUpRight = jsonObject->GetNumberField(TEXT("eyeLookUpRight")) * scale;
+	eyeSquintRight = jsonObject->GetNumberField(TEXT("eyeSquintRight")) * scale;
+	eyeWideRight = jsonObject->GetNumberField(TEXT("eyeWideRight")) * scale;
+	jawForward = jsonObject->GetNumberField(TEXT("jawForward")) * scale;
+	jawLeft = jsonObject->GetNumberField(TEXT("jawLeft")) * scale;
+	jawRight = jsonObject->GetNumberField(TEXT("jawRight")) * scale;
+	jawOpen = jsonObject->GetNumberField(TEXT("jawOpen")) * scale;
+	mouthClose = jsonObject->GetNumberField(TEXT("mouthClose")) * scale;
+	mouthFunnel = jsonObject->GetNumberField(TEXT("mouthFunnel")) * scale;
+	mouthPucker = jsonObject->GetNumberField(TEXT("mouthPucker")) * scale;
+	mouthLeft = jsonObject->GetNumberField(TEXT("mouthLeft")) * scale;
+	mouthRight = jsonObject->GetNumberField(TEXT("mouthRight")) * scale;
+	mouthSmileLeft = jsonObject->GetNumberField(TEXT("mouthSmileLeft")) * scale;
+	mouthSmileRight = jsonObject->GetNumberField(TEXT("mouthSmileRight")) * scale;
+	mouthFrownLeft = jsonObject->GetNumberField(TEXT("mouthFrownLeft")) * scale;
+	mouthFrownRight = jsonObject->GetNumberField(TEXT("mouthFrownRight")) * scale;
+	mouthDimpleLeft = jsonObject->GetNumberField(TEXT("mouthDimpleLeft")) * scale;
+	mouthDimpleRight = jsonObject->GetNumberField(TEXT("mouthDimpleRight")) * scale;
+	mouthStretchLeft = jsonObject->GetNumberField(TEXT("mouthStretchLeft")) * scale;
+	mouthStretchRight = jsonObject->GetNumberField(TEXT("mouthStretchRight")) * scale;
+	mouthRollLower = jsonObject->GetNumberField(TEXT("mouthRollLower")) * scale;
+	mouthRollUpper = jsonObject->GetNumberField(TEXT("mouthRollUpper")) * scale;
+	mouthShrugLower = jsonObject->GetNumberField(TEXT("mouthShrugLower")) * scale;
+	mouthShrugUpper = jsonObject->GetNumberField(TEXT("mouthShrugUpper")) * scale;
+	mouthPressLeft = jsonObject->GetNumberField(TEXT("mouthPressLeft")) * scale;
+	mouthPressRight = jsonObject->GetNumberField(TEXT("mouthPressRight")) * scale;
+	mouthLowerDownLeft = jsonObject->GetNumberField(TEXT("mouthLowerDownLeft")) * scale;
+	mouthLowerDownRight = jsonObject->GetNumberField(TEXT("mouthLowerDownRight")) * scale;
+	mouthUpperUpLeft = jsonObject->GetNumberField(TEXT("mouthUpperUpLeft")) * scale;
+	mouthUpperUpRight = jsonObject->GetNumberField(TEXT("mouthUpperUpRight")) * scale;
+	browDownLeft = jsonObject->GetNumberField(TEXT("browDownLeft")) * scale;
+	browDownRight = jsonObject->GetNumberField(TEXT("browDownRight")) * scale;
+	browInnerUp = jsonObject->GetNumberField(TEXT("browInnerUp")) * scale;
+	browOuterUpLeft = jsonObject->GetNumberField(TEXT("browOuterUpLeft")) * scale;
+	browOuterUpRight = jsonObject->GetNumberField(TEXT("browOuterUpRight")) * scale;
+	cheekPuff = jsonObject->GetNumberField(TEXT("cheekPuff")) * scale;
+	cheekSquintLeft = jsonObject->GetNumberField(TEXT("cheekSquintLeft")) * scale;
+	cheekSquintRight = jsonObject->GetNumberField(TEXT("cheekSquintRight")) * scale;
+	noseSneerLeft = jsonObject->GetNumberField(TEXT("noseSneerLeft")) * scale;
+	noseSneerRight = jsonObject->GetNumberField(TEXT("noseSneerRight")) * scale;
+	tongueOut = jsonObject->GetNumberField(TEXT("tongueOut")) * scale;
 }

--- a/Plugins/Smartsuit/Source/Smartsuit/Private/VirtualProductionFrame.cpp
+++ b/Plugins/Smartsuit/Source/Smartsuit/Private/VirtualProductionFrame.cpp
@@ -201,7 +201,7 @@ FFace::FFace(TSharedPtr<FJsonObject> jsonObject, const FString& InActorName)
 	}
 
 	constexpr float scale{ 0.01f };
-
+	
 	eyeBlinkLeft = jsonObject->GetNumberField(TEXT("eyeBlinkLeft")) * scale;
 	eyeLookDownLeft = jsonObject->GetNumberField(TEXT("eyeLookDownLeft")) * scale;
 	eyeLookInLeft = jsonObject->GetNumberField(TEXT("eyeLookInLeft")) * scale;

--- a/Plugins/Smartsuit/Source/Smartsuit/Private/VirtualProductionFrame.cpp
+++ b/Plugins/Smartsuit/Source/Smartsuit/Private/VirtualProductionFrame.cpp
@@ -201,7 +201,7 @@ FFace::FFace(TSharedPtr<FJsonObject> jsonObject, const FString& InActorName)
 	}
 
 	constexpr float scale{ 0.01f };
-	//fix all number fields with the depracated Passing an ANSI string to GetNumberField 
+
 	eyeBlinkLeft = jsonObject->GetNumberField(TEXT("eyeBlinkLeft")) * scale;
 	eyeLookDownLeft = jsonObject->GetNumberField(TEXT("eyeLookDownLeft")) * scale;
 	eyeLookInLeft = jsonObject->GetNumberField(TEXT("eyeLookInLeft")) * scale;

--- a/Plugins/Smartsuit/Source/Smartsuit/Private/VirtualProductionSource.cpp
+++ b/Plugins/Smartsuit/Source/Smartsuit/Private/VirtualProductionSource.cpp
@@ -1355,8 +1355,8 @@ void SuitParseBone(FSuitData* suitData, TSharedPtr<FJsonObject> jsonObject, cons
 	if (jsonObject->HasField(BoneName))
 	{
 		TSharedPtr<FJsonObject> BoneObject = jsonObject->GetObjectField(BoneName);
-		FVector SensorPosition = USmartsuitBlueprintLibrary::GetVectorField(BoneObject->GetObjectField("position"));
-		FQuat SensorRotation = USmartsuitBlueprintLibrary::GetQuaternionField(BoneObject->GetObjectField("rotation"));
+		FVector SensorPosition = USmartsuitBlueprintLibrary::GetVectorField(BoneObject->GetObjectField(TEXT("position")));
+		FQuat SensorRotation = USmartsuitBlueprintLibrary::GetQuaternionField(BoneObject->GetObjectField(TEXT("rotation")));
 
 		suitData->bones.Add(FName(*BoneName), FSmartsuitBone(FName(*BoneName), SensorPosition, SensorRotation));
 	}
@@ -1364,7 +1364,7 @@ void SuitParseBone(FSuitData* suitData, TSharedPtr<FJsonObject> jsonObject, cons
 
 void UpdateSuitFromJson(FSuitData* suitData, const TSharedPtr<FJsonObject> jsonObject)
 {
-	suitData->suitname = jsonObject->GetStringField("name");
+	suitData->suitname = jsonObject->GetStringField(TEXT("name"));
 
 	//temp
 	suitData->profileName = suitData->suitname;
@@ -1378,14 +1378,14 @@ void UpdateSuitFromJson(FSuitData* suitData, const TSharedPtr<FJsonObject> jsonO
 	//TArray<TSharedPtr<FJsonValue>> ColorArray = jsonObject->GetArrayField("color");
 	suitData->color = USmartsuitBlueprintLibrary::GetColorField(jsonObject);
 
-	TSharedPtr<FJsonObject> Meta = jsonObject->GetObjectField("meta");
-	suitData->hasGloves = Meta->GetBoolField("hasGloves");
-	suitData->hasLeftGlove = Meta->GetBoolField("hasLeftGlove");
-	suitData->hasRightGlove = Meta->GetBoolField("hasRightGlove");
-	suitData->hasBody = Meta->GetBoolField("hasBody");
-	suitData->hasFace = Meta->GetBoolField("hasFace");
+	TSharedPtr<FJsonObject> Meta = jsonObject->GetObjectField(TEXT("meta"));
+	suitData->hasGloves = Meta->GetBoolField(TEXT("hasGloves"));
+	suitData->hasLeftGlove = Meta->GetBoolField(TEXT("hasLeftGlove"));
+	suitData->hasRightGlove = Meta->GetBoolField(TEXT("hasRightGlove"));
+	suitData->hasBody = Meta->GetBoolField(TEXT("hasBody"));
+	suitData->hasFace = Meta->GetBoolField(TEXT("hasFace"));
 
-	TSharedPtr<FJsonObject> BodyObj = jsonObject->GetObjectField("body");
+	TSharedPtr<FJsonObject> BodyObj = jsonObject->GetObjectField(TEXT("body"));
 
 	SuitParseBone(suitData, BodyObj, SmartsuitBones::hip.ToString());
 	SuitParseBone(suitData, BodyObj, SmartsuitBones::spine.ToString());
@@ -1457,19 +1457,19 @@ void UpdateSuitFromJson(FSuitData* suitData, const TSharedPtr<FJsonObject> jsonO
 
 void UpdateCharacterFromJson(FCharacterData* characterData, const TSharedPtr<FJsonObject> jsonObject)
 {
-	characterData->CharacterName = jsonObject->GetStringField("name");
+	characterData->CharacterName = jsonObject->GetStringField(TEXT("name"));
 
-	TArray<TSharedPtr<FJsonValue>> JointsArray = jsonObject->GetArrayField("joints");
+	TArray<TSharedPtr<FJsonValue>> JointsArray = jsonObject->GetArrayField(TEXT("joints"));
 
 	for (TArray< TSharedPtr< FJsonValue > >::TConstIterator JointsIter(JointsArray.CreateConstIterator()); JointsIter; ++JointsIter)
 	{
 		const TSharedPtr< FJsonValue >  JointEntry = *JointsIter;
 		const TSharedPtr< FJsonObject > JoinJSONObject = JointEntry->AsObject();
 
-		FString JointName = JoinJSONObject->GetStringField("name");
-		int32 JointParentIndex = JoinJSONObject->GetIntegerField("parent");
-		FVector JointPosition = USmartsuitBlueprintLibrary::GetVectorField(JoinJSONObject->GetObjectField("position"));
-		FQuat JointRotation = USmartsuitBlueprintLibrary::GetQuaternionField(JoinJSONObject->GetObjectField("rotation"));
+		FString JointName = JoinJSONObject->GetStringField(TEXT("name"));
+		int32 JointParentIndex = JoinJSONObject->GetIntegerField(TEXT("parent"));
+		FVector JointPosition = USmartsuitBlueprintLibrary::GetVectorField(JoinJSONObject->GetObjectField(TEXT("position")));
+		FQuat JointRotation = USmartsuitBlueprintLibrary::GetQuaternionField(JoinJSONObject->GetObjectField(TEXT("rotation")));
 
 		FTransform JointTransform(JointRotation, JointPosition, FVector::OneVector);
 		characterData->joints.Add(FRokokoCharacterJoint(*JointName, JointParentIndex, JointTransform));
@@ -1478,34 +1478,34 @@ void UpdateCharacterFromJson(FCharacterData* characterData, const TSharedPtr<FJs
 
 void UpdateNewtonsFromJson(FNewtonData* newtonData, const TSharedPtr<FJsonObject> jsonObject)
 {
-	if (jsonObject->HasField("name"))
+	if (jsonObject->HasField(TEXT("name")))
 	{
-		newtonData->NewtonName = jsonObject->GetStringField("name");
+		newtonData->NewtonName = jsonObject->GetStringField(TEXT("name"));
 	}
 	else
 	{
 		newtonData->NewtonName = "UnknownName";
 	}
 
-	if (jsonObject->HasField("meta"))
+	if (jsonObject->HasField(TEXT("meta")))
 	{
-		TSharedPtr<FJsonObject> Meta = jsonObject->GetObjectField("meta");
-		newtonData->HasFace = Meta->GetBoolField("hasFace");
+		TSharedPtr<FJsonObject> Meta = jsonObject->GetObjectField(TEXT("meta"));
+		newtonData->HasFace = Meta->GetBoolField(TEXT("hasFace"));
 	}
 
-	if (jsonObject->HasField("joints"))
+	if (jsonObject->HasField(TEXT("joints")))
 	{
-		TArray<TSharedPtr<FJsonValue>> JointsArray = jsonObject->GetArrayField("joints");
+		TArray<TSharedPtr<FJsonValue>> JointsArray = jsonObject->GetArrayField(TEXT("joints"));
 
 		for (const auto& JointElem : JointsArray)
 		{
 			const TSharedPtr< FJsonObject > JoinJSONObject = JointElem->AsObject();
 
 			FRokokoCharacterJoint CharacterJoint;
-			CharacterJoint.name = *JoinJSONObject->GetStringField("name");
-			CharacterJoint.parentIndex = JoinJSONObject->GetIntegerField("parent");
-			CharacterJoint.position = USmartsuitBlueprintLibrary::GetVectorField(JoinJSONObject->GetObjectField("position"));
-			CharacterJoint.rotation = USmartsuitBlueprintLibrary::GetQuaternionField(JoinJSONObject->GetObjectField("rotation"));
+			CharacterJoint.name = *JoinJSONObject->GetStringField(TEXT("name"));
+			CharacterJoint.parentIndex = JoinJSONObject->GetIntegerField(TEXT("parent"));
+			CharacterJoint.position = USmartsuitBlueprintLibrary::GetVectorField(JoinJSONObject->GetObjectField(TEXT("position")));
+			CharacterJoint.rotation = USmartsuitBlueprintLibrary::GetQuaternionField(JoinJSONObject->GetObjectField(TEXT("rotation")));
 			FTransform JointTransform(CharacterJoint.rotation, CharacterJoint.position, FVector::OneVector);
 			CharacterJoint.transform = JointTransform;
 			newtonData->Joints.Add(MoveTemp(CharacterJoint));
@@ -1583,14 +1583,14 @@ uint32 FVirtualProductionSource::Run()
 		if (FJsonSerializer::Deserialize(Reader, JsonObject))
 		{
 
-			VPFrame.Version = JsonObject->GetStringField("version");
+			VPFrame.Version = JsonObject->GetStringField(TEXT("version"));
 			
 			//SCENE
 			{
-				TSharedPtr<FJsonObject> SceneObj = JsonObject->GetObjectField("scene");
-				if (SceneObj->HasField("props"))
+				TSharedPtr<FJsonObject> SceneObj = JsonObject-> GetObjectField(TEXT("scene"));
+				if (SceneObj->HasField(TEXT("props")))
 				{
-					TArray<TSharedPtr<FJsonValue>> Livepropsarray = SceneObj->GetArrayField("props");
+					TArray<TSharedPtr<FJsonValue>> Livepropsarray = SceneObj->GetArrayField(TEXT("props"));
 
 					for (auto& currentprop : Livepropsarray)
 					{
@@ -1599,10 +1599,10 @@ uint32 FVirtualProductionSource::Run()
 					}
 				}
 
-				if (SceneObj->HasField("actors"))
+				if (SceneObj->HasField(TEXT("actors")))
 				{
 
-					TArray<TSharedPtr<FJsonValue>> LivesuitsArray = SceneObj->GetArrayField("actors");
+					TArray<TSharedPtr<FJsonValue>> LivesuitsArray = SceneObj->GetArrayField(TEXT("actors"));
 					for (auto& currentsuit : LivesuitsArray)
 					{
 						FSuitData SuitData; // = FSuitData(true, currentsuit->AsObject());
@@ -1611,7 +1611,7 @@ uint32 FVirtualProductionSource::Run()
 
 						if (SuitData.hasFace)
 						{
-							auto JSONObjectface = currentsuit->AsObject()->GetObjectField("face");
+							auto JSONObjectface = currentsuit->AsObject()->GetObjectField(TEXT("face"));
 							auto FaceData = FFace(JSONObjectface, SuitData.suitname);
 							SuitData.faceId = FaceData.faceId;
 							VPFrame.Faces.Emplace(MoveTemp(FaceData));
@@ -1620,9 +1620,9 @@ uint32 FVirtualProductionSource::Run()
 					}
 				}
 
-				if (SceneObj->HasField("newtons"))
+				if (SceneObj->HasField(TEXT("newtons")))
 				{
-					TArray<TSharedPtr<FJsonValue>> NewtonsArray = SceneObj->GetArrayField("newtons");
+					TArray<TSharedPtr<FJsonValue>> NewtonsArray = SceneObj->GetArrayField(TEXT("newtons"));
 					for (auto& currentNewton : NewtonsArray)
 					{
 						FNewtonData NewtonData;
@@ -1639,9 +1639,9 @@ uint32 FVirtualProductionSource::Run()
 					}
 				}
 
-				if (SceneObj->HasField("characters"))
+				if (SceneObj->HasField(TEXT("characters")))
 				{
-					TArray<TSharedPtr<FJsonValue>> CharactersArray = SceneObj->GetArrayField("characters");
+					TArray<TSharedPtr<FJsonValue>> CharactersArray = SceneObj->GetArrayField(TEXT("characters"));
 					for (auto& currentcharacter : CharactersArray)
 					{
 						FCharacterData CharacterData;

--- a/Plugins/Smartsuit/Source/Smartsuit/Private/VirtualProductionSource.cpp
+++ b/Plugins/Smartsuit/Source/Smartsuit/Private/VirtualProductionSource.cpp
@@ -1631,7 +1631,7 @@ uint32 FVirtualProductionSource::Run()
 
 						if (NewtonData.HasFace)
 						{
-							auto JSONObjectface = currentNewton->AsObject()->GetObjectField("face");
+							auto JSONObjectface = currentNewton->AsObject()->GetObjectField(TEXT("face"));
 							auto FaceData = FFace(JSONObjectface, NewtonData.NewtonName);
 							VPFrame.Faces.Emplace(MoveTemp(FaceData));
 						}

--- a/Plugins/Smartsuit/Source/Smartsuit/Public/RokokoSkeletonData.h
+++ b/Plugins/Smartsuit/Source/Smartsuit/Public/RokokoSkeletonData.h
@@ -200,9 +200,9 @@ struct FRokokoCharacterJoint
 
 	FName name;
 	int32 parentIndex;
+	FTransform transform;
 	FVector position;
 	FQuat rotation;
-	FTransform transform;
 };
 
 USTRUCT()


### PR DESCRIPTION
Hello,
This PR fixes a few compilation issues on Linux and a few deprecation warnings (I assume for every platform)

## Compilation error

```
UnrealEngine-5.4.4/Engine/Plugins/Smartsuit/Source/Smartsuit/Public/RokokoSkeletonData.h:196:5: error: field 'transform' will be initialized after field 'position' [-Werror,-Wreorder-ctor]
                , transform(Transform)
                  ^~~~~~~~~~~~~~~~~~~~
                  position(Position)
```

## Deprecation API usage (instance example)

```
Engine/Plugins/Smartsuit/Source/Smartsuit/Private/VirtualProductionSource.cpp:1625:62: warning: 'GetArrayField' is deprecated: Passing an ANSI string to GetArrayField has been deprecated outside of UTF-8 mode. Please use the overload that takes a TCHAR string. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
                                        TArray<TSharedPtr<FJsonValue>> NewtonsArray = SceneObj->GetArrayField("newtons");
```

