### PR TITLE
Fix include order deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ ToRelease/
 
 #vscode
 .vscode/
+.ignore
+*.code-workspace
+
+#Linux
+Makefile

--- a/Source/RokokoUEPlugin.Target.cs
+++ b/Source/RokokoUEPlugin.Target.cs
@@ -9,7 +9,7 @@ public class RokokoUEPluginTarget : TargetRules
 	{
 		Type = TargetType.Game;
 		DefaultBuildSettings = BuildSettingsVersion.V5;
-		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_4;
+		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_6;
 		ExtraModuleNames.Add("RokokoUEPlugin");
 	}
 }

--- a/Source/RokokoUEPluginEditor.Target.cs
+++ b/Source/RokokoUEPluginEditor.Target.cs
@@ -9,7 +9,7 @@ public class RokokoUEPluginEditorTarget : TargetRules
 	{
 		Type = TargetType.Editor;
 		DefaultBuildSettings = BuildSettingsVersion.V5;
-		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_4;
+		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_6;
 		ExtraModuleNames.Add("RokokoUEPlugin");
 	}
 }


### PR DESCRIPTION
Fixes include order setting which is deprecated and will reportedly be removed in 5.7

```
/home/vnicolaou/rokoko-studio-live-unreal-engine/Source/RokokoUEPluginEditor.Target.cs(12,25): warning CS0618: 'EngineIncludeOrderVersion.Unreal5_4' is obsolete: 'The Unreal 5.4 include order is deprecated and will be unsupported in 5.7.'
/home/vnicolaou/rokoko-studio-live-unreal-engine/Source/RokokoUEPlugin.Target.cs(12,25): warning CS0618: 'EngineIncludeOrderVersion.Unreal5_4' is obsolete: 'The Unreal 5.4 include order is deprecated and will be unsupported in 5.7.'
```

Shouldn't really affect anything, but would be good to do a fresh compilation and brief test just in case